### PR TITLE
feat: load home page from portfolio data

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ portfolio-streamlit-codex/
 pip install -r requirements.txt
 ```
 
-### 2. 애플리케이션 실행
+### 2. 환경 변수 설정
+
+프로젝트 루트에 `.env` 파일을 생성하고 OpenAI API 키를 저장합니다. 애플리케이션은 실행 시 `.env` 파일을 자동으로 로드합니다.
+
+```
+OPENAI_API_KEY=sk-...
+```
+
+### 3. 애플리케이션 실행
 
 ```bash
 streamlit run app.py
@@ -61,11 +69,17 @@ python -m streamlit run app.py
 - **프로젝트 필터링**: 카테고리별 프로젝트 보기
 - **LangChain 챗봇**: MultiQueryRetriever와 FAISS를 활용한 포트폴리오 질의응답
 
+### 🗂 데이터 관리
+
+- 홈 화면은 `portfolio_data.json` 파일의 내용을 기반으로 개인 소개, 경력, 대표 프로젝트를 동적으로 렌더링합니다.
+- 연락처 페이지 역시 동일한 JSON 데이터를 참조하여 이메일, 전화번호, 소셜 링크를 표시합니다.
+- JSON 필드를 수정하면 앱을 재실행하지 않아도 Streamlit의 자동 새로고침을 통해 최신 정보가 즉시 반영됩니다.
+
 ## LangChain 기반 챗봇 사용법
 
 1. **포트폴리오 PDF 교체**: `assets/portfolio.pdf` 파일을 자신의 최신 포트폴리오 PDF로 교체합니다.
 2. **OpenAI API Key 설정**:
-   - 환경 변수 `OPENAI_API_KEY`를 설정하거나,
+   - `.env` 파일 또는 시스템 환경 변수에 `OPENAI_API_KEY`를 설정하거나,
    - 앱 실행 후 사이드바에서 API 키를 직접 입력합니다.
 3. **애플리케이션 실행**: 위 설치 절차에 따라 앱을 실행합니다.
 4. **챗봇 페이지 이동**: 사이드바에서 `🤖 챗봇` 페이지를 선택한 뒤 질문을 입력하면, LangChain `MultiQueryRetriever`와 `faiss-cpu` 벡터 DB, OpenAI `text-embedding-3-small` 임베딩 모델, `gpt-5-mini` 챗 모델을 사용해 답변을 생성합니다.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ langchain-openai>=0.1.0
 langchain-community>=0.0.30
 faiss-cpu>=1.7.4
 pypdf>=4.0.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## 변경점
- `.env` 파일을 자동으로 로드하도록 하고 `portfolio_data.json`을 캐시하여 홈/연락처 화면을 실제 데이터 기반으로 렌더링하도록 수정했습니다.
- 홈 화면에서 개인 정보, 경력, 대표 프로젝트를 JSON 데이터에 맞춰 표시하도록 개편하고, 연락처 화면에서도 동일한 데이터를 활용하도록 개선했습니다.
- OpenAI 키 설정 절차와 JSON 데이터 사용 방법을 README에 추가하고 `python-dotenv` 의존성을 포함했습니다.

## 영향도
- `.env` 파일이 존재하지 않거나 JSON 형식이 잘못된 경우 홈 화면과 사이드바에 오류 메시지가 표시됩니다.
- 기존 하드코딩된 소개/연락처 정보가 JSON을 통해 관리되므로 데이터 수정 시 앱 전반에 즉시 반영됩니다.

## 롤백 전략
- 문제가 발생하면 `app.py`, `README.md`, `requirements.txt`의 변경사항을 이전 커밋으로 되돌립니다.

## 테스트
- python -m compileall app.py portfolio_chatbot.py

------
https://chatgpt.com/codex/tasks/task_e_68d3ecfcc564833096ff846f7eccf1bd